### PR TITLE
HOCS-1491

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/search/application/queue/SearchConsumer.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/application/queue/SearchConsumer.java
@@ -64,6 +64,7 @@ public class SearchConsumer extends RouteBuilder {
                 .logRetryStackTrace(true));
 
         from(searchQueue).routeId("searchCommandRoute")
+                .noDelayer()
                 .setProperty(SqsConstants.RECEIPT_HANDLE, header(SqsConstants.RECEIPT_HANDLE))
                 .process(transferHeadersToMDC())
                 .log(LoggingLevel.INFO, "Audit message received")


### PR DESCRIPTION
Issues with the migration have shown that SQS messages are being consumed very slowly.
The audit consumer does not have delays so it is hereby set here too.