### PR TITLE
HOCS-1754 - Closed cases are showing up in 'Include Active Only' sear…

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilder.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilder.java
@@ -156,7 +156,7 @@ class HocsQueryBuilder {
     HocsQueryBuilder activeOnlyFlag(Boolean activeOnly) {
         if (activeOnly != null && activeOnly) {
             log.debug("activeOnly is true size, adding to query");
-            QueryBuilder activeQb = QueryBuilders.matchQuery("completed", false).operator(Operator.AND);
+            QueryBuilder activeQb = QueryBuilders.boolQuery().mustNot(QueryBuilders.matchQuery("completed", true));
             mqb.must(activeQb);
             hasClause = true;
         } else {

--- a/src/main/java/uk/gov/digital/ho/hocs/search/client/elasticsearchclient/ElasticSearchClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/client/elasticsearchclient/ElasticSearchClient.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.search.client.elasticsearchclient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import net.logstash.logback.encoder.org.apache.commons.lang.BooleanUtils;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -37,6 +38,8 @@ public class ElasticSearchClient {
     private final RestHighLevelClient client;
 
     private final String index;
+
+    private static final String COMPLETED = "completed";
 
     @Autowired
     public ElasticSearchClient(ObjectMapper objectMapper, RestHighLevelClient client, @Value("${elastic.index.prefix}") String prefix) {
@@ -142,6 +145,10 @@ public class ElasticSearchClient {
 
         Map<String, Object> result = new HashMap<>(map);
         result.values().removeAll(Arrays.asList("", null));
+
+        if(result.containsKey(COMPLETED) && !((boolean ) result.get(COMPLETED))){
+            result.remove(COMPLETED);
+        }
 
         return result;
     }


### PR DESCRIPTION
…ch results

the bug is most likely cased when more than 2 search services are running which can potentially lead to the last 'case_updated' event being processed after the 'case_completed'. The case_updated would always override the 'completed' flag to false. My change is here to make sure we don't submit this flag unless it is set to 'true'. Completing a case is not reversible in the platform so the change in logic is valid.