### PR TITLE
HOCS-2680: handle override private office

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/search/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/api/CaseDataService.java
@@ -151,6 +151,7 @@ public class CaseDataService {
         hocsQueryBuilder.correspondentReference(request.getCorrespondentReference());
         hocsQueryBuilder.correspondentExternalKey(request.getCorrespondentExternalKey());
         hocsQueryBuilder.topic(request.getTopic());
+        hocsQueryBuilder.privateOfficeTeam(request.getPrivateOfficeTeamUuid());
         hocsQueryBuilder.dataFields(request.getData());
         hocsQueryBuilder.activeOnlyFlag(request.getActiveOnly());
 

--- a/src/main/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilder.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilder.java
@@ -167,6 +167,34 @@ class HocsQueryBuilder {
         return this;
     }
 
+    HocsQueryBuilder privateOfficeTeam(String privateOfficeTeam) {
+        if (privateOfficeTeam != null && !privateOfficeTeam.isEmpty()) {
+            log.debug("Private office team {}, adding to query", privateOfficeTeam);
+
+            BoolQueryBuilder isOverridePoTeamQB = QueryBuilders.boolQuery()
+                    .must(QueryBuilders.matchQuery("data.OverridePOTeamUUID", privateOfficeTeam).operator(Operator.AND));
+
+            BoolQueryBuilder emptyOverrideIsPoTeamQB = QueryBuilders.boolQuery()
+                    .mustNot(QueryBuilders.wildcardQuery("data.OverridePOTeamUUID", "*"))
+                    .must(QueryBuilders.matchQuery("data.POTeamUUID", privateOfficeTeam).operator(Operator.AND));
+
+            BoolQueryBuilder noOverrideIsPoTeamQB = QueryBuilders.boolQuery()
+                    .mustNot(QueryBuilders.existsQuery("data.OverridePOTeamUUID"))
+                    .must(QueryBuilders.matchQuery("data.POTeamUUID", privateOfficeTeam).operator(Operator.AND));
+
+            BoolQueryBuilder privateOfficeFilter = new BoolQueryBuilder()
+                    .should(isOverridePoTeamQB)
+                    .should(emptyOverrideIsPoTeamQB)
+                    .should(noOverrideIsPoTeamQB);
+
+            mqb.must(privateOfficeFilter);
+            hasClause = true;
+        } else {
+            log.debug("Private office team was null or empty");
+        }
+        return this;
+    }
+
     HocsQueryBuilder dataFields(Map<String, String> data) {
         if (data != null && !data.isEmpty()) {
             log.debug("data size {}, adding to query", data.size());

--- a/src/main/java/uk/gov/digital/ho/hocs/search/api/dto/SearchRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/api/dto/SearchRequest.java
@@ -39,6 +39,9 @@ public class SearchRequest {
     @JsonProperty("topic")
     private String topic;
 
+    @JsonProperty("poTeamUuid")
+    private String privateOfficeTeamUuid;
+
     @JsonProperty("data")
     private Map<String, String> data;
 

--- a/src/test/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilderTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilderTest.java
@@ -402,4 +402,34 @@ public class HocsQueryBuilderTest {
 
         Mockito.verifyNoMoreInteractions(bqb);
     }
+
+    @Test
+    public void shouldAddPrivateOfficeTeam() {
+        String privateOfficeTeamUuid = UUID.randomUUID().toString();
+
+        HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
+        hocsQueryBuilder.privateOfficeTeam(privateOfficeTeamUuid);
+
+        Mockito.verify(bqb).must(any(QueryBuilder.class));
+
+        assertThat(bqb.toString()).contains(privateOfficeTeamUuid);
+    }
+
+    @Test
+    public void shouldNotAddEmptyPrivateOfficeTeam() {
+        String privateOfficeTeamUuid = "";
+
+        HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
+        hocsQueryBuilder.privateOfficeTeam(privateOfficeTeamUuid);
+
+        Mockito.verifyNoMoreInteractions(bqb);
+    }
+
+    @Test
+    public void shouldNotAddNullPrivateOfficeTeam() {
+        HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
+        hocsQueryBuilder.privateOfficeTeam(null);
+
+        Mockito.verifyNoMoreInteractions(bqb);
+    }
 }


### PR DESCRIPTION
Currently we only search private office against the `POTeamUUID`. 
As we allow for overrides the cases are not showing in search results.
This change adds a boolean query that filters on the following three 
conditions:
- If the Override is the specified
- If the Override is empty and the POTeamUUID is the specified
- If the Override doesn't exist and the POTeamUUID is the specified