### PR TITLE
HOCS-3207: fix up somu type UUID

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/search/api/dto/SomuItemDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/api/dto/SomuItemDto.java
@@ -17,8 +17,8 @@ public class SomuItemDto {
     @JsonProperty("uuid")
     private UUID uuid;
 
-    @JsonProperty("somuUuid")
-    private UUID somuUuid;
+    @JsonProperty("somuTypeUuid")
+    private UUID somuTypeUuid;
 
     @JsonProperty("data")
     private Object data;

--- a/src/main/java/uk/gov/digital/ho/hocs/search/domain/model/SomuItem.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/domain/model/SomuItem.java
@@ -14,8 +14,8 @@ import java.util.UUID;
 public class SomuItem {
 
     private UUID uuid;
-    
-    private UUID somuUuid;
+
+    private UUID somuTypeUuid;
 
     private Object data;
     

--- a/src/main/java/uk/gov/digital/ho/hocs/search/domain/model/SomuItem.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/domain/model/SomuItem.java
@@ -20,6 +20,6 @@ public class SomuItem {
     private Object data;
     
     public static SomuItem from(SomuItemDto somuItemDto) {
-        return new SomuItem(somuItemDto.getUuid(), somuItemDto.getSomuUuid(), somuItemDto.getData());
+        return new SomuItem(somuItemDto.getUuid(), somuItemDto.getSomuTypeUuid(), somuItemDto.getData());
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/search/domain/model/CaseDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/search/domain/model/CaseDataTest.java
@@ -235,7 +235,7 @@ public class CaseDataTest {
 
         assertThat(caseData.getAllSomuItems()).hasSize(1);
 
-        SomuItem updatedSomuItem = SomuItem.from(new SomuItemDto(validSomuItem.getUuid(), validSomuItem.getSomuUuid(), "TEST"));
+        SomuItem updatedSomuItem = SomuItem.from(new SomuItemDto(validSomuItem.getUuid(), validSomuItem.getSomuTypeUuid(), "TEST"));
         
         caseData.updateSomuItem(updatedSomuItem);
 
@@ -243,7 +243,7 @@ public class CaseDataTest {
         
         SomuItem caseDataSomuItem = (SomuItem)caseData.getAllSomuItems().toArray()[0];
         assertThat(caseDataSomuItem.getUuid()).isEqualTo(validSomuItem.getUuid());
-        assertThat(caseDataSomuItem.getSomuUuid()).isEqualTo(validSomuItem.getSomuUuid());
+        assertThat(caseDataSomuItem.getSomuTypeUuid()).isEqualTo(validSomuItem.getSomuTypeUuid());
         assertThat(caseDataSomuItem.getData()).isEqualTo("TEST");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/search/domain/model/SomuItemTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/search/domain/model/SomuItemTest.java
@@ -18,7 +18,7 @@ public class SomuItemTest {
         SomuItem somuItem = SomuItem.from(validSomuItemDto);
 
         assertThat(somuItem.getUuid()).isEqualTo(somuItemUUID);
-        assertThat(somuItem.getSomuUuid()).isEqualTo(somuTypeUUID);
+        assertThat(somuItem.getSomuTypeUuid()).isEqualTo(somuTypeUUID);
         assertThat(somuItem.getData()).isEqualTo("{}");
     }
 }


### PR DESCRIPTION
Currently search is looking for the JSON property `somuUuid` 
on incoming somu item changes. This is being passed through 
correctly as `somuTypeUuid` so the JSON property mapping 
needs to be amended to use this correct value.

Upon mapping the SomuItem to JSON to be updated in the search 
index it is currently using `somuUuid` instead of `somuTypeUuid`.