### PR TITLE
Feature/hocs 3307 upgrade springboot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,16 @@ dependencies {
     implementation('org.springframework.retry:spring-retry')
     implementation('org.springframework:spring-aspects')
 
+
+    // Override the default version of elasticSearch, we're still using V6
+    def elasticSearchVersion = '6.8.3'
+    implementation('org.elasticsearch:elasticsearch:' + elasticSearchVersion)
+    implementation('org.elasticsearch.client:elasticsearch-rest-client:' + elasticSearchVersion)
+    implementation('org.elasticsearch:elasticsearch-x-content:' + elasticSearchVersion)
+    implementation('org.elasticsearch:elasticsearch-cli:' + elasticSearchVersion)
+    implementation('org.elasticsearch:elasticsearch-core:' + elasticSearchVersion)
+    implementation('org.elasticsearch:elasticsearch-secure-sm:' + elasticSearchVersion)
+
     implementation('org.apache.camel:camel-spring-boot:2.24.0')
     implementation('org.apache.camel:camel-jackson:2.24.0')
     implementation('org.apache.camel:camel-aws:2.24.0')

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation('com.amazonaws:aws-java-sdk:1.11.553')
     implementation('javax.xml.bind:jaxb-api:2.3.0')
 
-    implementation('org.elasticsearch.client:elasticsearch-rest-high-level-client:7.6.2')
+    implementation('org.elasticsearch.client:elasticsearch-rest-high-level-client:6.6.2')
     implementation 'com.github.awslabs:aws-request-signing-apache-interceptor:b3772780da'
 
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.2.0.RELEASE'
+    id 'org.springframework.boot' version '2.3.0.RELEASE'
     id 'java'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,12 +49,12 @@ dependencies {
 
     // Override the default version of elasticSearch, we're still using V6
     def elasticSearchVersion = '6.8.3'
-    implementation('org.elasticsearch:elasticsearch:' + elasticSearchVersion)
-    implementation('org.elasticsearch.client:elasticsearch-rest-client:' + elasticSearchVersion)
-    implementation('org.elasticsearch:elasticsearch-x-content:' + elasticSearchVersion)
-    implementation('org.elasticsearch:elasticsearch-cli:' + elasticSearchVersion)
-    implementation('org.elasticsearch:elasticsearch-core:' + elasticSearchVersion)
-    implementation('org.elasticsearch:elasticsearch-secure-sm:' + elasticSearchVersion)
+    implementation("org.elasticsearch:elasticsearch:${elasticSearchVersion}")
+    implementation("org.elasticsearch.client:elasticsearch-rest-client:${elasticSearchVersion}")
+    implementation("org.elasticsearch:elasticsearch-x-content:${elasticSearchVersion}")
+    implementation("org.elasticsearch:elasticsearch-cli:${elasticSearchVersion}")
+    implementation("org.elasticsearch:elasticsearch-core:${elasticSearchVersion}")
+    implementation("org.elasticsearch:elasticsearch-secure-sm:${elasticSearchVersion}")
 
     implementation('org.apache.camel:camel-spring-boot:2.24.0')
     implementation('org.apache.camel:camel-jackson:2.24.0')

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation('com.amazonaws:aws-java-sdk:1.11.553')
     implementation('javax.xml.bind:jaxb-api:2.3.0')
 
-    implementation('org.elasticsearch.client:elasticsearch-rest-high-level-client:6.6.2')
+    implementation('org.elasticsearch.client:elasticsearch-rest-high-level-client:7.6.2')
     implementation 'com.github.awslabs:aws-request-signing-apache-interceptor:b3772780da'
 
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
Upgrade to SpringBoot 2.3.0.

A side effect of this was the, behind the scenes, upgrade of elasticSearch from 6 to 7.

This would mean upgrading all environments to use V7
Instead, I've overridden the verson back to what we were using before upgrading SpringBoot