### PR TITLE
Feature/hocs 3363 upgrade to spring boot 2.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.3.0.RELEASE'
+    id 'org.springframework.boot' version '2.5.1'
     id 'java'
 }
 
@@ -72,4 +72,8 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation("org.apache.camel:camel-test-spring:2.24.0")
     testImplementation('org.assertj:assertj-core')
+}
+
+jar {
+    enabled = false
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/search/HocsSearchApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/HocsSearchApplication.java
@@ -18,7 +18,7 @@ public class HocsSearchApplication {
 
     @PreDestroy
     public void stop() {
-        log.info("hocs-search stopping gracefully");
+        log.info("Stopping gracefully");
     }
 
 }


### PR DESCRIPTION
- Upgrade to SpringBoot 2.5.1
- Remove app name from logging. 