### PR TITLE
HOCS-3253: Change private office team search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation("org.apache.camel:camel-test-spring:2.24.0")
     testImplementation('org.assertj:assertj-core')
+    testImplementation('net.javacrumbs.json-unit:json-unit-assertj:2.27.0')
 }
 
 jar {

--- a/src/main/java/uk/gov/digital/ho/hocs/search/api/QueryBuilderHelpers.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/search/api/QueryBuilderHelpers.java
@@ -1,0 +1,17 @@
+package uk.gov.digital.ho.hocs.search.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.index.query.*;
+
+@Slf4j
+class QueryBuilderHelpers {
+
+    static ExistsQueryBuilder fieldExists(String fieldName) {
+        return QueryBuilders.existsQuery(fieldName);
+    }
+
+    static WildcardQueryBuilder nonEmptyField(String fieldName) {
+        return QueryBuilders.wildcardQuery(fieldName, "*");
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilderTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilderTest.java
@@ -43,7 +43,7 @@ public class HocsQueryBuilderTest {
     @Test
     public void shouldAddNumericReferenceWithSingleCaseType() {
         String reference = "123";
-        List<String> caseTypes = Arrays.asList("TYPE");
+        List<String> caseTypes = Collections.singletonList("TYPE");
 
         HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
         hocsQueryBuilder.reference(reference, caseTypes);
@@ -57,7 +57,7 @@ public class HocsQueryBuilderTest {
     @Test
     public void shouldAddNonNumericReferenceWithSingleCaseType() {
         String reference = "reference123";
-        List<String> caseTypes = Arrays.asList("TYPE");
+        List<String> caseTypes = Collections.singletonList("TYPE");
 
         HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
         hocsQueryBuilder.reference(reference, caseTypes);
@@ -231,7 +231,8 @@ public class HocsQueryBuilderTest {
     public void shouldAddCorrespondentNameNotMember(){
         String correspondentNameNotMember = "BOB";
 
-        HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb).correspondentNameNotMember(correspondentNameNotMember);
+        HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
+        hocsQueryBuilder.correspondentNameNotMember(correspondentNameNotMember);
 
         Mockito.verify(bqb).must(any(QueryBuilder.class));
         assertThat(bqb.toString()).contains("BOB");
@@ -398,29 +399,22 @@ public class HocsQueryBuilderTest {
 
     @Test
     public void shouldAddActiveFalse() {
-        Boolean activeOnly = false;
-
         HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
-        hocsQueryBuilder.activeOnlyFlag(activeOnly);
+        hocsQueryBuilder.activeOnlyFlag(false);
 
         Mockito.verifyNoMoreInteractions(bqb);
-
     }
 
     @Test
     public void shouldAddActiveTrue() {
-        Boolean activeOnly = true;
-
         HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
-        hocsQueryBuilder.activeOnlyFlag(activeOnly);
+        hocsQueryBuilder.activeOnlyFlag(true);
 
         Mockito.verify(bqb).must(any(QueryBuilder.class));
-
     }
 
     @Test
     public void shouldNotAddActive() {
-
         HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
         hocsQueryBuilder.dataFields(null);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilderTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/search/api/HocsQueryBuilderTest.java
@@ -13,6 +13,7 @@ import uk.gov.digital.ho.hocs.search.api.dto.DateRangeDto;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.mockito.ArgumentMatchers.any;
 
 
@@ -498,14 +499,50 @@ public class HocsQueryBuilderTest {
 
     @Test
     public void shouldAddPrivateOfficeTeam() {
-        String privateOfficeTeamUuid = UUID.randomUUID().toString();
+        final String privateOfficeTeamUuid = UUID.randomUUID().toString();
+        final List<Map<String, String>> privateOfficeJsonPaths =
+                List.of(
+                        Map.of("$['bool']['must'][0]['match']['data.PrivateOfficeOverridePOTeamUUID']['query']", privateOfficeTeamUuid),
+                        Map.of("$['bool']['must'][0]['match']['data.OverridePOTeamUUID']['query']", privateOfficeTeamUuid,
+                                "$['bool']['must_not'][0]['exists']['field']", "data.PrivateOfficeOverridePOTeamUUID"),
+                        Map.of("$['bool']['must'][0]['match']['data.OverridePOTeamUUID']['query']", privateOfficeTeamUuid,
+                                "$['bool']['must_not'][0]['wildcard']['data.PrivateOfficeOverridePOTeamUUID']['wildcard']", "*"),
+                        Map.of("$['bool']['must'][0]['match']['data.POTeamUUID']['query']", privateOfficeTeamUuid,
+                                "$['bool']['must_not'][0]['exists']['field']", "data.PrivateOfficeOverridePOTeamUUID",
+                                "$['bool']['must_not'][1]['exists']['field']", "data.OverridePOTeamUUID"),
+                        Map.of("$['bool']['must'][0]['match']['data.POTeamUUID']['query']", privateOfficeTeamUuid,
+                                "$['bool']['must_not'][0]['exists']['field']", "data.PrivateOfficeOverridePOTeamUUID",
+                                "$['bool']['must_not'][1]['wildcard']['data.OverridePOTeamUUID']['wildcard']", "*"),
+                        Map.of("$['bool']['must'][0]['match']['data.POTeamUUID']['query']", privateOfficeTeamUuid,
+                                "$['bool']['must_not'][0]['wildcard']['data.PrivateOfficeOverridePOTeamUUID']['wildcard']", "*",
+                                "$['bool']['must_not'][1]['exists']['field']", "data.OverridePOTeamUUID"),
+                        Map.of("$['bool']['must'][0]['match']['data.POTeamUUID']['query']", privateOfficeTeamUuid,
+                                "$['bool']['must_not'][0]['wildcard']['data.PrivateOfficeOverridePOTeamUUID']['wildcard']", "*",
+                                "$['bool']['must_not'][1]['wildcard']['data.OverridePOTeamUUID']['wildcard']", "*")
+                );
 
         HocsQueryBuilder hocsQueryBuilder = new HocsQueryBuilder(bqb);
         hocsQueryBuilder.privateOfficeTeam(privateOfficeTeamUuid);
 
+        // Retrieve the overarching core must query
         Mockito.verify(bqb).must(any(QueryBuilder.class));
+        assertThat(bqb.must().size()).isEqualTo(1);
+        BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) bqb.must().get(0);
 
-        assertThat(bqb.toString()).contains(privateOfficeTeamUuid);
+        // Private office has 7 underlying should queries
+        assertThat(boolQueryBuilder.should().size()).isEqualTo(7);
+        for(int i = 0; i < boolQueryBuilder.should().size(); i++) {
+            BoolQueryBuilder shouldQuery = (BoolQueryBuilder)boolQueryBuilder.should().get(i);
+
+            Map<String, String> jsonPaths = privateOfficeJsonPaths.get(i);
+
+            for (Map.Entry<String, String> entry : jsonPaths.entrySet()) {
+                assertThatJson(shouldQuery.toString())
+                        .inPath(entry.getKey())
+                        .isString()
+                        .isEqualTo(entry.getValue());
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
An issue has arised whereby cases can be assigned to a private 
office team in the `Private Office Approval` screen that acts as an 
override for the previous selections. This screens value is saved 
under the `PrivateOfficeOverridePOTeamUUID` field name. Too 
allow for the searching of this value, the private office query builder 
needs to be modified to look at this value. As a result the other 
checks for the older values have to change in line to accommodate 
this. 
New helpers for checking if a field exists and whether the field 
exists with a value have been added to simplify the function.